### PR TITLE
Add topic to RoomServiceClient's sendData method

### DIFF
--- a/src/RoomServiceClient.php
+++ b/src/RoomServiceClient.php
@@ -301,22 +301,28 @@ class RoomServiceClient extends BaseServiceClient {
    *   The delivery reliability.
    * @param string[] $destinationSids
    *   Optional, when empty, message is sent to everyone.
+   * @param ?string $topic
+   *   Optional, topic is used to route the stream to the appropriate handler.
    *
    * @return \Livekit\SendDataResponse
    *   The SendDataResponse object.
    */
-  public function sendData(string $roomName, string $data, int $kind, array $destinationSids = []): SendDataResponse {
+  public function sendData(string $roomName, string $data, int $kind, array $destinationSids = [], ?string $topic = null): SendDataResponse {
     $videoGrant = new VideoGrant();
     $videoGrant->setRoomName($roomName);
     $videoGrant->setRoomAdmin();
-    return $this->rpc->SendData(
-      $this->authHeader($videoGrant),
-      new SendDataRequest([
+    $requestData = [
         'room' => $roomName,
         'data' => $data,
         'kind' => $kind,
         'destination_sids' => $destinationSids,
-      ])
+    ];
+    if (!empty($topic)) {
+        $requestData['topic'] = $topic;
+    }
+    return $this->rpc->SendData(
+      $this->authHeader($videoGrant),
+      new SendDataRequest($requestData)
     );
   }
 


### PR DESCRIPTION
I would like to be able to send a topic with the data message to make the client side easier to handle.

As far as I can tell all other server SDKs are capable of sending a data message with a topic. I think this small change can make the client side cleaner, when it comes to sending messages from a PHP backend.

I added the `$topic` as the last optional parameter to the `sendData` method and only append it to the message, when it is not empty to make sure that it behaves exactly as before, without the topic option.

If you think it doesn't fit the code style or anything please let me know and I try to make it work for you!

