### PR TITLE
Support for Laravel 12 — packages updated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "require": {
         "php": "^8.0",
         "firebase/php-jwt": "^6.8",
-        "twirp/twirp": "^0.9.1",
-        "google/protobuf": "^3.23",
+        "twirp/twirp": "^0.9.1|^0.13.0",
+        "google/protobuf": "^3.23|^4.30",
         "guzzlehttp/guzzle": "^6.3|^7.0",
         "guzzlehttp/psr7": "^1.6.1|^2.0"
     },
@@ -26,6 +26,11 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.4"
+        "phpunit/phpunit": "^12.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     }
 }

--- a/tests/EgressServiceClientTest.php
+++ b/tests/EgressServiceClientTest.php
@@ -2,46 +2,40 @@
 
 namespace Agence104\LiveKit\Tests;
 
-use Livekit\TrackType;
+use Agence104\LiveKit\EgressServiceClient;
+use Agence104\LiveKit\RoomServiceClient;
+use Exception;
 use Livekit\EgressInfo;
+use Livekit\ListEgressResponse;
+use Livekit\StreamInfo\Status;
 use Livekit\StreamOutput;
 use Livekit\StreamProtocol;
-use Livekit\StreamInfo\Status;
-use Livekit\ListEgressResponse;
+use Livekit\TrackType;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
-use Agence104\LiveKit\RoomServiceClient;
-use Agence104\LiveKit\EgressServiceClient;
 
 class EgressServiceClientTest extends TestCase {
 
   /**
    * The egress service client instance.
-   *
-   * @var EgressServiceClient
    */
-  private $client;
+  private EgressServiceClient $client;
 
   /**
    * The room name of the main room with participants.
    * This room is created prior to running the tests.
-   *
-   * @var string
    */
-  private $mainRoom = 'testRoomParticipants';
+  private string $mainRoom = 'testRoomParticipants';
 
   /**
    * The RTMP url to use to test StreamOutput.
-   *
-   * @var string
    */
-  private $rtmpUrl;
+  private string $rtmpUrl;
 
   /**
    * The RTMP url2 to use to test StreamOutput.
-   *
-   * @var string
    */
-  private $rtmpUrl2;
+  private string $rtmpUrl2;
 
   protected function setUp(): void {
     $this->rtmpUrl = getenv('LIVEKIT_EGRESS_RTMP_URL')
@@ -52,7 +46,7 @@ class EgressServiceClientTest extends TestCase {
     try {
       $this->client = new EgressServiceClient();
     }
-    catch(\Exception $e) {
+    catch(Exception $e) {
       $this->fail('Failed to set up EgressServiceClient: ' . $e->getMessage());
     }
   }
@@ -65,14 +59,14 @@ class EgressServiceClientTest extends TestCase {
       foreach($response->getItems() as $egress) {
         try {
           $client->stopEgress($egress->getEgressId());
-        } catch (\Exception $e) {}
+        } catch (Exception $e) {}
       }
     }
-    catch(\Exception $e) {}
+    catch(Exception $e) {}
     parent::tearDownAfterClass();
   }
 
-  public function testStartRoomCompositeEgress() {
+  public function testStartRoomCompositeEgress(): string {
     $output = new StreamOutput([
       'protocol' => StreamProtocol::RTMP,
       'urls' => [$this->rtmpUrl]
@@ -95,10 +89,8 @@ class EgressServiceClientTest extends TestCase {
     return $response->getEgressId();
   }
 
-  /**
-   * @depends testStartRoomCompositeEgress
-   */
-  public function testUpdateLayoutEgress($egressId) {
+  #[Depends('testStartRoomCompositeEgress')]
+  public function testUpdateLayoutEgress(string $egressId): void {
     $response = $this->client->updateLayout($egressId, 'speaker');
     $this->assertInstanceOf(EgressInfo::class, $response);
 
@@ -110,10 +102,8 @@ class EgressServiceClientTest extends TestCase {
     sleep(10);
   }
 
-  /**
-   * @depends testStartRoomCompositeEgress
-   */
-  public function testUpdateStream($egressId) {
+  #[Depends('testStartRoomCompositeEgress')]
+  public function testUpdateStream(string $egressId): void {
     // Let's add the second url.
     $response = $this->client->updateStream($egressId, [$this->rtmpUrl2]);
     $this->assertInstanceOf(EgressInfo::class, $response);
@@ -152,10 +142,8 @@ class EgressServiceClientTest extends TestCase {
     sleep(5);
   }
 
-  /**
-   * @depends testStartRoomCompositeEgress
-   */
-  public function testListEgress($egressId) {
+  #[Depends('testStartRoomCompositeEgress')]
+  public function testListEgress(string $egressId): void {
     $response = $this->client->listEgress($this->mainRoom);
     $this->assertInstanceOf(ListEgressResponse::class, $response);
     $this->assertGreaterThanOrEqual(1, $response->getItems()->count());
@@ -177,15 +165,13 @@ class EgressServiceClientTest extends TestCase {
     $this->assertGreaterThanOrEqual(1, $response->getItems()->count());
   }
 
-  /**
-   * @depends testStartRoomCompositeEgress
-   */
-  public function testStopEgress($egressId) {
+  #[Depends('testStartRoomCompositeEgress')]
+  public function testStopEgress(string $egressId): void {
     try {
       $response = $this->client->stopEgress($egressId);
       $this->assertInstanceOf(EgressInfo::class, $response);
     }
-    catch(\Exception $e) {
+    catch(Exception $e) {
       $this->fail('Error deleting Ingress: ' . $e->getMessage());
     }
 
@@ -193,7 +179,7 @@ class EgressServiceClientTest extends TestCase {
     sleep(10);
   }
 
-  public function testStartWebEgress() {
+  public function testStartWebEgress(): void {
     $output = new StreamOutput([
       'protocol' => StreamProtocol::RTMP,
       'urls' => [$this->rtmpUrl]
@@ -215,11 +201,11 @@ class EgressServiceClientTest extends TestCase {
     $this->client->stopEgress($egressId);
   }
 
-  public function testStartTrackCompositeEgress() {
+  public function testStartTrackCompositeEgress(): void {
     try {
       $roomClient = new RoomServiceClient();
     }
-    catch(\Exception $e) {
+    catch(Exception $e) {
       $this->fail('Failed to set up RoomServiceClient: ' . $e->getMessage());
     }
     $videoTrackId = null;
@@ -275,11 +261,11 @@ class EgressServiceClientTest extends TestCase {
     sleep(10);
   }
 
-  public function testStartTrackEgress() {
+  public function testStartTrackEgress(): string {
     try {
       $roomClient = new RoomServiceClient();
     }
-    catch(\Exception $e) {
+    catch(Exception $e) {
       $this->fail('Failed to set up RoomServiceClient: ' . $e->getMessage());
     }
     $trackId = null;

--- a/tests/IngressServiceClientTest.php
+++ b/tests/IngressServiceClientTest.php
@@ -2,34 +2,32 @@
 
 namespace Agence104\LiveKit\Tests;
 
+use Agence104\LiveKit\IngressServiceClient;
+use Exception;
 use Livekit\IngressInfo;
 use Livekit\IngressInput;
-use PHPUnit\Framework\TestCase;
 use Livekit\ListIngressResponse;
-use Agence104\LiveKit\IngressServiceClient;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\TestCase;
 
 class IngressServiceClientTest extends TestCase {
 
   /**
    * The ingress service client instance.
-   *
-   * @var IngressServiceClient
    */
-  private $client;
+  private IngressServiceClient $client;
 
   /**
    * The room name of the main room with participants.
    * This room is created prior to running the tests.
-   *
-   * @var string
    */
-  private $mainRoom = 'testRoomParticipants';
+  private string $mainRoom = 'testRoomParticipants';
 
   protected function setUp(): void {
     try {
       $this->client = new IngressServiceClient();
     }
-    catch(\Exception $e) {
+    catch(Exception $e) {
       $this->fail('Failed to set up IngressServiceClient: ' . $e->getMessage());
     }
   }
@@ -47,11 +45,11 @@ class IngressServiceClientTest extends TestCase {
         $client->deleteIngress($ingress->getIngressId());
       }
     }
-    catch(\Exception $e) {}
+    catch(Exception $e) {}
     parent::tearDownAfterClass();
   }
 
-  private function validateIngressExists($ingressId) {
+  private function validateIngressExists($ingressId): bool {
     if (empty($ingressId)) {
       $this->fail('Test Ingress not found!');
       return false;
@@ -60,7 +58,7 @@ class IngressServiceClientTest extends TestCase {
     return true;
   }
 
-  public function testCreateIngress() {
+  public function testCreateIngress(): string {
     $name = 'testIngress';
     $participantIdentity = 'ingress-test-user';
     $participantName = 'Ingress Test User';
@@ -82,10 +80,9 @@ class IngressServiceClientTest extends TestCase {
     return $response->getIngressId();
   }
 
-  /**
-   * @depends testCreateIngress
-   */
-  public function testUpdateIngress($ingressId) {
+
+  #[Depends('testCreateIngress')]
+  public function testUpdateIngress(string $ingressId): void {
     $name = 'testIngress-2';
     $participantIdentity = 'ingress-test-user-2';
     $participantName = 'Ingress Test User 2';
@@ -108,10 +105,8 @@ class IngressServiceClientTest extends TestCase {
     $this->assertEquals($this->mainRoom, $response->getRoomName());
   }
 
-  /**
-   * @depends testCreateIngress
-   */
-  public function testListIngress($ingressId) {
+  #[Depends('testCreateIngress')]
+  public function testListIngress(string $ingressId): void {
     $response = $this->client->listIngress();
     $this->assertInstanceOf(ListIngressResponse::class, $response);
     $this->assertEquals(1, $response->getItems()->count());
@@ -121,10 +116,8 @@ class IngressServiceClientTest extends TestCase {
     );
   }
 
-  /**
-   * @depends testCreateIngress
-   */
-  public function testDeleteIngress($ingressId) {
+  #[Depends('testCreateIngress')]
+  public function testDeleteIngress(string $ingressId): void {
     if (!$this->validateIngressExists($ingressId)) {
       return;
     }
@@ -133,7 +126,7 @@ class IngressServiceClientTest extends TestCase {
       $response = $this->client->deleteIngress($ingressId);
       $this->assertInstanceOf(IngressInfo::class, $response);
     }
-    catch(\Exception $e) {
+    catch(Exception $e) {
       $this->fail('Error deleting Ingress: ' . $e->getMessage());
     }
   }


### PR DESCRIPTION
Updated twirp, google protobuf and phpunit.
Refactor tests to use typed properties as it is deprecated on phpunit 12.

This update is mandatory for **Laravel 12** projects, hence the PR.

---

I was NOT able to run the tests for **`Egress`** even in the current version, even with a youtube api key.
**`Ingress`** and **`Room Service Client`** work fine 👌

```php
Ingress Service Client (Agence104\LiveKit\Tests\IngressServiceClient)
 ✔ Create ingress
 ✔ Update ingress
 ✔ List ingress
 ✔ Delete ingress

Room Service Client (Agence104\LiveKit\Tests\RoomServiceClient)
 ✔ Create room
 ✔ List rooms
 ✔ Delete room
 ✔ Update room metadata
 ✔ List participants
 ✔ Get participant
 ✔ Remove participant
 ✔ Mute published track
 ✔ Update participant
 ✔ Update subscriptions
 ✔ Send data
```

@p-delorme if you can instruct me on how to run the Egress tests I'll gladly do it.