### PR TITLE
PHP 8.4: Add explicit nullable type declarations

### DIFF
--- a/src/proto/Google/Protobuf/TwirpError.php
+++ b/src/proto/Google/Protobuf/TwirpError.php
@@ -23,7 +23,7 @@ final class TwirpError extends \Exception implements Error
      */
     private $meta = [];
 
-    public function __construct(string $code, string $message, int $exCode = 0, \Throwable $previous = null)
+    public function __construct(string $code, string $message, int $exCode = 0, ?\Throwable $previous = null)
     {
         $this->errorCode = $code;
 
@@ -72,7 +72,7 @@ final class TwirpError extends \Exception implements Error
      * error {type: Internal, msg: "invalid error type {code}"}. If you need to
      * add metadata, use setMeta(key, value) method after building the error.
      */
-    public static function newError(string $code, string $msg, \Throwable $previous = null): self
+    public static function newError(string $code, string $msg, ?\Throwable $previous = null): self
     {
         if (ErrorCode::isValid($code)) {
             return new self($code, $msg, 0, $previous);

--- a/src/proto/Livekit/AgentDispatchServiceAbstractClient.php
+++ b/src/proto/Livekit/AgentDispatchServiceAbstractClient.php
@@ -53,9 +53,9 @@ abstract class AgentDispatchServiceAbstractClient
 
     public function __construct(
         $addr,
-        ClientInterface $httpClient = null,
-        RequestFactoryInterface $requestFactory = null,
-        StreamFactoryInterface $streamFactory = null,
+        ?ClientInterface $httpClient = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
         string $prefix = '/twirp'
     ) {
         if ($httpClient === null) {

--- a/src/proto/Livekit/AgentDispatchServiceServer.php
+++ b/src/proto/Livekit/AgentDispatchServiceServer.php
@@ -62,9 +62,9 @@ final class AgentDispatchServiceServer implements RequestHandlerInterface
 
     public function __construct(
         AgentDispatchService $svc,
-        ServerHooks $hook = null,
-        ResponseFactoryInterface $responseFactory = null,
-        StreamFactoryInterface $streamFactory = null,
+        ?ServerHooks $hook = null,
+        ?ResponseFactoryInterface $responseFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
         string $prefix = '/twirp'
     ) {
         if ($hook === null) {

--- a/src/proto/Livekit/EgressAbstractClient.php
+++ b/src/proto/Livekit/EgressAbstractClient.php
@@ -53,9 +53,9 @@ abstract class EgressAbstractClient
 
     public function __construct(
         $addr,
-        ClientInterface $httpClient = null,
-        RequestFactoryInterface $requestFactory = null,
-        StreamFactoryInterface $streamFactory = null,
+        ?ClientInterface $httpClient = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
         string $prefix = '/twirp'
     ) {
         if ($httpClient === null) {

--- a/src/proto/Livekit/EgressServer.php
+++ b/src/proto/Livekit/EgressServer.php
@@ -62,9 +62,9 @@ final class EgressServer implements RequestHandlerInterface
 
     public function __construct(
         Egress $svc,
-        ServerHooks $hook = null,
-        ResponseFactoryInterface $responseFactory = null,
-        StreamFactoryInterface $streamFactory = null,
+        ?ServerHooks $hook = null,
+        ?ResponseFactoryInterface $responseFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
         string $prefix = '/twirp'
     ) {
         if ($hook === null) {

--- a/src/proto/Livekit/IngressAbstractClient.php
+++ b/src/proto/Livekit/IngressAbstractClient.php
@@ -53,9 +53,9 @@ abstract class IngressAbstractClient
 
     public function __construct(
         $addr,
-        ClientInterface $httpClient = null,
-        RequestFactoryInterface $requestFactory = null,
-        StreamFactoryInterface $streamFactory = null,
+        ?ClientInterface $httpClient = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
         string $prefix = '/twirp'
     ) {
         if ($httpClient === null) {

--- a/src/proto/Livekit/IngressServer.php
+++ b/src/proto/Livekit/IngressServer.php
@@ -62,9 +62,9 @@ final class IngressServer implements RequestHandlerInterface
 
     public function __construct(
         Ingress $svc,
-        ServerHooks $hook = null,
-        ResponseFactoryInterface $responseFactory = null,
-        StreamFactoryInterface $streamFactory = null,
+        ?ServerHooks $hook = null,
+        ?ResponseFactoryInterface $responseFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
         string $prefix = '/twirp'
     ) {
         if ($hook === null) {

--- a/src/proto/Livekit/RoomServiceAbstractClient.php
+++ b/src/proto/Livekit/RoomServiceAbstractClient.php
@@ -53,9 +53,9 @@ abstract class RoomServiceAbstractClient
 
     public function __construct(
         $addr,
-        ClientInterface $httpClient = null,
-        RequestFactoryInterface $requestFactory = null,
-        StreamFactoryInterface $streamFactory = null,
+        ?ClientInterface $httpClient = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
         string $prefix = '/twirp'
     ) {
         if ($httpClient === null) {

--- a/src/proto/Livekit/RoomServiceServer.php
+++ b/src/proto/Livekit/RoomServiceServer.php
@@ -62,9 +62,9 @@ final class RoomServiceServer implements RequestHandlerInterface
 
     public function __construct(
         RoomService $svc,
-        ServerHooks $hook = null,
-        ResponseFactoryInterface $responseFactory = null,
-        StreamFactoryInterface $streamFactory = null,
+        ?ServerHooks $hook = null,
+        ?ResponseFactoryInterface $responseFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
         string $prefix = '/twirp'
     ) {
         if ($hook === null) {

--- a/src/proto/Livekit/SIPAbstractClient.php
+++ b/src/proto/Livekit/SIPAbstractClient.php
@@ -53,9 +53,9 @@ abstract class SIPAbstractClient
 
     public function __construct(
         $addr,
-        ClientInterface $httpClient = null,
-        RequestFactoryInterface $requestFactory = null,
-        StreamFactoryInterface $streamFactory = null,
+        ?ClientInterface $httpClient = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
         string $prefix = '/twirp'
     ) {
         if ($httpClient === null) {

--- a/src/proto/Livekit/SIPServer.php
+++ b/src/proto/Livekit/SIPServer.php
@@ -62,9 +62,9 @@ final class SIPServer implements RequestHandlerInterface
 
     public function __construct(
         SIP $svc,
-        ServerHooks $hook = null,
-        ResponseFactoryInterface $responseFactory = null,
-        StreamFactoryInterface $streamFactory = null,
+        ?ServerHooks $hook = null,
+        ?ResponseFactoryInterface $responseFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
         string $prefix = '/twirp'
     ) {
         if ($hook === null) {

--- a/src/proto/Livekit/TwirpError.php
+++ b/src/proto/Livekit/TwirpError.php
@@ -23,7 +23,7 @@ final class TwirpError extends \Exception implements Error
      */
     private $meta = [];
 
-    public function __construct(string $code, string $message, int $exCode = 0, \Throwable $previous = null)
+    public function __construct(string $code, string $message, int $exCode = 0, ?\Throwable $previous = null)
     {
         $this->errorCode = $code;
 
@@ -72,7 +72,7 @@ final class TwirpError extends \Exception implements Error
      * error {type: Internal, msg: "invalid error type {code}"}. If you need to
      * add metadata, use setMeta(key, value) method after building the error.
      */
-    public static function newError(string $code, string $msg, \Throwable $previous = null): self
+    public static function newError(string $code, string $msg, ?\Throwable $previous = null): self
     {
         if (ErrorCode::isValid($code)) {
             return new self($code, $msg, 0, $previous);


### PR DESCRIPTION
Fixed implicitly nullable parameter declarations warnings. This is a prominent deprecation in PHP 8.4 and it is causing deprecation notices in our production system.